### PR TITLE
Fix Arm Compiler support

### DIFF
--- a/aws_credentials.h
+++ b/aws_credentials.h
@@ -8,36 +8,45 @@ namespace credentials {
 /*
  * PEM-encoded root CA certificate
  *
- * Must include the PEM header and footer:
- * "-----BEGIN CERTIFICATE-----"
- * "...base64 data..."
+ * Must include the PEM header and footer,
+ * and every line of the body needs to be quoted and end with \n:
+ * "-----BEGIN CERTIFICATE-----\n"
+ * "...base64 data...\n"
  * "-----END CERTIFICATE-----";
  */
 const char rootCA[] = "-----BEGIN CERTIFICATE-----\n"
+"...\n"
+"...\n"
 "...\n"
 "-----END CERTIFICATE-----";
 
 /*
  * PEM-encoded client certificate
  *
- * Must include the PEM header and footer:
- * "-----BEGIN CERTIFICATE-----"
- * "...base64 data..."
+ * Must include the PEM header and footer,
+ * and every line of the body needs to be quoted and end with \n:
+ * "-----BEGIN CERTIFICATE-----\n"
+ * "...base64 data...\n"
  * "-----END CERTIFICATE-----";
  */
 const char clientCrt[] = "-----BEGIN CERTIFICATE-----\n"
+"...\n"
+"...\n"
 "...\n"
 "-----END CERTIFICATE-----";
 
 /*
  * PEM-encoded client private key.
  *
- * Must include the PEM header and footer:
- * "-----BEGIN RSA PRIVATE KEY-----"
- * "...base64 data..."
+ * Must include the PEM header and footer,
+ * and every line of the body needs to be quoted and end with \n:
+ * "-----BEGIN RSA PRIVATE KEY-----\n"
+ * "...base64 data...\n"
  * "-----END RSA PRIVATE KEY-----";
  */
 const char clientKey[] = "-----BEGIN RSA PRIVATE KEY-----\n"
+"...\n"
+"...\n"
 "...\n"
 "-----END RSA PRIVATE KEY-----";
 

--- a/main.cpp
+++ b/main.cpp
@@ -139,7 +139,7 @@ int main()
 
         /* prepare the message */
         static char message[64];
-        snprintf(message, 64, "Warning: Only %lu seconde(s) left to say your name !", 10 - i);
+        snprintf(message, 64, "Warning: Only %lu second(s) left to say your name !", 10 - i);
         publish.pPayload = message;
         publish.payloadLength = strlen(message);
 

--- a/mbed-aws-client.lib
+++ b/mbed-aws-client.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-aws-client.git#788d956b14484901bcabc737e03d21f56c1738b4
+https://github.com/ARMmbed/mbed-aws-client.git#455937ace2ddeb5078ea0c71ba51bf1b6fa67b6a

--- a/mbed_app.json
+++ b/mbed_app.json
@@ -18,7 +18,7 @@
             "mbed-trace.enable": true,
             "mbed-trace.max-level": "TRACE_LEVEL_INFO",
             "aws-client.log-puts": "aws_iot_puts",
-            "aws-client.log-level-global": "IOT_LOG_DEBUG",
+            "aws-client.log-level-global": "IOT_LOG_INFO",
             "rtos.main-thread-stack-size": 8192,
             "rtos.thread-stack-size": 2048,
             "platform.error-filename-capture-enabled": true,

--- a/mbed_app.json
+++ b/mbed_app.json
@@ -20,6 +20,7 @@
             "aws-client.log-puts": "aws_iot_puts",
             "aws-client.log-level-global": "IOT_LOG_DEBUG",
             "rtos.main-thread-stack-size": 8192,
+            "rtos.thread-stack-size": 2048,
             "platform.error-filename-capture-enabled": true,
             "platform.stdio-convert-newlines": true,
             "platform.stdio-baud-rate": 115200


### PR DESCRIPTION
To build & run the example with the Arm Compiler, we need to
* Fix build issues in mbed-aws-client. ~Preceding PR: https://github.com/ARMmbed/mbed-aws-client/pull/4~ (merged)
* Reduce stack memory size so all the threads can fit into DISCO_L475VG_IOT01A RAM (128KB, as opposed to K64F's 256KB). Without this PR, the memory usage is _borderline_ too much probably, failing with ARMC6 and working with GCC_ARM.
Out-of-memory happened when mbed-aws-client allocates the IoTClock SystemTimer thread's stack memory on DISCO_L475VG_IOT01A.

Fixes: #3